### PR TITLE
feat: compact memo editor UI with improved spacing and layout

### DIFF
--- a/web/src/components/MemoEditor/ActionButton/AddMemoRelationPopover.tsx
+++ b/web/src/components/MemoEditor/ActionButton/AddMemoRelationPopover.tsx
@@ -129,16 +129,16 @@ const AddMemoRelationPopover = (props: Props) => {
 
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <PopoverTrigger className="w-9 relative">
-        <Button className="flex items-center justify-center" size="sm" variant="plain" asChild>
-          <LinkIcon className="w-5 h-5 mx-auto p-0" />
+      <PopoverTrigger asChild>
+        <Button className="flex items-center justify-center" size="sm" variant="plain">
+          <LinkIcon className="w-4 h-4 mx-auto" />
         </Button>
       </PopoverTrigger>
       <PopoverContent align="center">
-        <div className="w-[16rem] flex flex-col justify-start items-start">
+        <div className="w-[14rem] flex flex-col justify-start items-start">
           <Autocomplete
             className="w-full"
-            size="md"
+            size="sm"
             clearOnBlur
             disableClearable
             placeholder={t("reference.search-placeholder")}
@@ -153,26 +153,26 @@ const AddMemoRelationPopover = (props: Props) => {
             getOptionLabel={(memo) => memo.content}
             isOptionEqualToValue={(memo, value) => memo.name === value.name}
             renderOption={(props, memo) => (
-              <AutocompleteOption {...props} key={memo.name}>
+              <AutocompleteOption {...props} key={memo.name} sx={{ py: 0.5 }}>
                 <div className="w-full flex flex-col justify-start items-start">
                   <p className="text-xs text-gray-400 select-none">{memo.displayTime?.toLocaleString()}</p>
-                  <p className="mt-0.5 text-sm leading-5 line-clamp-2">{searchText ? getHighlightedContent(memo.content) : memo.snippet}</p>
+                  <p className="text-sm leading-4 line-clamp-2">{searchText ? getHighlightedContent(memo.content) : memo.snippet}</p>
                 </div>
               </AutocompleteOption>
             )}
             renderTags={(memos) =>
               memos.map((memo) => (
-                <Chip key={memo.name} className="!max-w-full !rounded" variant="outlined" color="neutral">
+                <Chip key={memo.name} className="max-w-full rounded" size="sm" variant="outlined" color="neutral">
                   <div className="w-full flex flex-col justify-start items-start">
                     <p className="text-xs text-gray-400 select-none">{memo.displayTime?.toLocaleString()}</p>
-                    <span className="w-full text-sm leading-5 truncate">{memo.content}</span>
+                    <span className="w-full text-xs leading-4 truncate">{memo.content}</span>
                   </div>
                 </Chip>
               ))
             }
             onChange={(_, value) => setSelectedMemos(value)}
           />
-          <div className="mt-2 w-full flex flex-row justify-end items-center gap-2">
+          <div className="mt-1.5 w-full flex flex-row justify-end items-center gap-1.5">
             <Checkbox size="sm" label={"Embed"} checked={embedded} onChange={(e) => setEmbedded(e.target.checked)} />
             <Button size="sm" color="primary" onClick={addMemoRelations} disabled={selectedMemos.length === 0}>
               {t("common.add")}

--- a/web/src/components/MemoEditor/ActionButton/LocationSelector.tsx
+++ b/web/src/components/MemoEditor/ActionButton/LocationSelector.tsx
@@ -95,11 +95,11 @@ const LocationSelector = (props: Props) => {
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverTrigger asChild>
         <Button className="flex items-center justify-center" size="sm" variant="plain">
-          <MapPinIcon className="w-5 h-5 mx-auto shrink-0" />
+          <MapPinIcon className="w-4 h-4 mx-auto shrink-0" />
           {props.location && (
             <>
               <span className="ml-0.5 text-sm text-ellipsis whitespace-nowrap overflow-hidden max-w-32">{props.location.placeholder}</span>
-              <XIcon className="w-5 h-5 mx-auto shrink-0 hidden group-hover:block opacity-60 hover:opacity-80" onClick={removeLocation} />
+              <XIcon className="w-4 h-4 mx-auto shrink-0 hidden group-hover:block opacity-60 hover:opacity-80" onClick={removeLocation} />
             </>
           )}
         </Button>

--- a/web/src/components/MemoEditor/ActionButton/MarkdownMenu.tsx
+++ b/web/src/components/MemoEditor/ActionButton/MarkdownMenu.tsx
@@ -64,20 +64,20 @@ const MarkdownMenu = (props: Props) => {
     <Dropdown>
       <MenuButton slots={{ root: "div" }}>
         <Button size="sm" variant="plain">
-          <SquareSlashIcon className="w-5 h-5 mx-auto" />
+          <SquareSlashIcon className="w-4 h-4 mx-auto" />
         </Button>
       </MenuButton>
-      <Menu className="text-sm" size="sm" placement="bottom-start">
-        <MenuItem onClick={handleCodeBlockClick}>
-          <Code2Icon className="w-4 h-auto" />
+      <Menu className="text-sm" size="sm" sx={{ py: 0.5, minWidth: "auto" }} placement="bottom-start">
+        <MenuItem sx={{ py: 0.5, minHeight: "auto", gap: 0.75 }} onClick={handleCodeBlockClick}>
+          <Code2Icon className="w-3.5 h-auto" />
           <span>{t("markdown.code-block")}</span>
         </MenuItem>
-        <MenuItem onClick={handleCheckboxClick}>
-          <CheckSquareIcon className="w-4 h-auto" />
+        <MenuItem sx={{ py: 0.5, minHeight: "auto", gap: 0.75 }} onClick={handleCheckboxClick}>
+          <CheckSquareIcon className="w-3.5 h-auto" />
           <span>{t("markdown.checkbox")}</span>
         </MenuItem>
-        <div className="-mt-0.5 pl-2">
-          <Link fontSize={12} href="https://www.usememos.com/docs/getting-started/content-syntax" target="_blank">
+        <div className="py-0.5 pl-2">
+          <Link fontSize={11} href="https://www.usememos.com/docs/getting-started/content-syntax" target="_blank">
             {t("markdown.content-syntax")}
           </Link>
         </div>

--- a/web/src/components/MemoEditor/ActionButton/TagSelector.tsx
+++ b/web/src/components/MemoEditor/ActionButton/TagSelector.tsx
@@ -43,18 +43,18 @@ const TagSelector = (props: Props) => {
     <Dropdown open={open} onOpenChange={(_, isOpen) => setOpen(isOpen)}>
       <MenuButton slots={{ root: "div" }}>
         <Button size="sm" variant="plain">
-          <HashIcon className="w-5 h-5 mx-auto" />
+          <HashIcon className="w-4 h-4 mx-auto" />
         </Button>
       </MenuButton>
       <Menu className="relative" component="div" size="sm" placement="bottom-start">
         <div ref={containerRef}>
           {tags.length > 0 ? (
-            <div className="flex flex-row justify-start items-start flex-wrap px-3 py-1 max-w-[12rem] h-auto max-h-48 overflow-y-auto gap-x-2 gap-y-1">
+            <div className="flex flex-row justify-start items-start flex-wrap px-2 py-1 max-w-[12rem] h-auto max-h-48 overflow-y-auto gap-x-2 gap-y-0.5">
               {tags.map((tag) => {
                 return (
                   <div
                     key={tag}
-                    className="inline-flex w-auto max-w-full cursor-pointer text-base leading-6 text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary-dark"
+                    className="inline-flex w-auto max-w-full cursor-pointer text-sm leading-5 text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary-dark"
                     onClick={() => handleTagClick(tag)}
                   >
                     <OverflowTip>#{tag}</OverflowTip>
@@ -63,7 +63,7 @@ const TagSelector = (props: Props) => {
               })}
             </div>
           ) : (
-            <p className="italic mx-2" onClick={(e) => e.stopPropagation()}>
+            <p className="italic text-sm mx-2" onClick={(e) => e.stopPropagation()}>
               {t("tag.no-tag-found")}
             </p>
           )}

--- a/web/src/components/MemoEditor/ActionButton/UploadResourceButton.tsx
+++ b/web/src/components/MemoEditor/ActionButton/UploadResourceButton.tsx
@@ -67,7 +67,7 @@ const UploadResourceButton = () => {
 
   return (
     <Button className="relative" size="sm" variant="plain" disabled={state.uploadingFlag}>
-      <PaperclipIcon className="w-5 h-5 mx-auto" />
+      <PaperclipIcon className="w-4 h-4 mx-auto" />
       <input
         className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
         ref={fileInputRef}

--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -193,8 +193,8 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
       )}
     >
       <textarea
-        className="w-full h-full my-1 text-base resize-none overflow-x-hidden overflow-y-auto bg-transparent outline-none whitespace-pre-wrap word-break"
-        rows={1}
+        className="w-full h-full text-sm resize-none overflow-x-hidden overflow-y-auto bg-transparent outline-none whitespace-pre-wrap word-break"
+        rows={2}
         placeholder={placeholder}
         ref={editorRef}
         onPaste={onPaste}

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -1,7 +1,7 @@
-import { Select, Option, Divider } from "@mui/joy";
+import { Select, Option } from "@mui/joy";
 import { Button } from "@usememos/mui";
 import { isEqual } from "lodash-es";
-import { LoaderIcon, SendIcon } from "lucide-react";
+import { LoaderIcon, SendIcon, XIcon } from "lucide-react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -422,7 +422,7 @@ const MemoEditor = (props: Props) => {
       <div
         className={`${
           className ?? ""
-        } relative w-full flex flex-col justify-start items-start bg-white dark:bg-zinc-800 px-4 pt-4 rounded-lg border border-gray-200 dark:border-zinc-700`}
+        } relative w-full flex flex-col justify-start items-start bg-white dark:bg-zinc-800 p-3 pb-2 rounded-lg border border-gray-200 dark:border-zinc-700`}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onDrop={handleDropEvent}
@@ -442,10 +442,10 @@ const MemoEditor = (props: Props) => {
         <Editor ref={editorRef} {...editorConfig} />
         <ResourceListView resourceList={state.resourceList} setResourceList={handleSetResourceList} />
         <RelationListView relationList={referenceRelations} setRelationList={handleSetRelationList} />
-        <div className="relative w-full flex flex-row justify-between items-center pt-2" onFocus={(e) => e.stopPropagation()}>
-          <div className="flex flex-row justify-start items-center opacity-80 dark:opacity-60 -space-x-1">
+        <div className="w-full mt-2 flex flex-row justify-between items-center" onFocus={(e) => e.stopPropagation()}>
+          <div className="flex flex-row justify-start items-center gap-0.5 opacity-80 dark:opacity-60">
             <TagSelector editorRef={editorRef} />
-            <MarkdownMenu editorRef={editorRef} />
+            {/* <MarkdownMenu editorRef={editorRef} /> */}
             <UploadResourceButton />
             <AddMemoRelationPopover editorRef={editorRef} />
             {workspaceMemoRelatedSetting.enableLocation && (
@@ -460,16 +460,13 @@ const MemoEditor = (props: Props) => {
               />
             )}
           </div>
-        </div>
-        <Divider className="!mt-2 opacity-40" />
-        <div className="w-full flex flex-row justify-between items-center py-3 gap-2 overflow-auto dark:border-t-zinc-500">
-          <div className="relative flex flex-row justify-start items-center" onFocus={(e) => e.stopPropagation()}>
+          <div className="shrink-0 flex flex-row justify-end items-center gap-0.5">
             <Select
-              className="!text-sm"
+              className="!min-w-0"
               variant="plain"
-              size="md"
+              size="sm"
               value={state.memoVisibility}
-              startDecorator={<VisibilityIcon visibility={state.memoVisibility} />}
+              renderValue={() => <VisibilityIcon visibility={state.memoVisibility} />}
               onChange={(_, visibility) => {
                 if (visibility) {
                   handleMemoVisibilityChange(visibility);
@@ -477,21 +474,22 @@ const MemoEditor = (props: Props) => {
               }}
             >
               {[Visibility.PRIVATE, Visibility.PROTECTED, Visibility.PUBLIC].map((item) => (
-                <Option key={item} value={item} className="whitespace-nowrap !text-sm">
+                <Option key={item} value={item} className="whitespace-nowrap text-sm">
                   {t(`memo.visibility.${convertVisibilityToString(item).toLowerCase()}` as any)}
                 </Option>
               ))}
             </Select>
-          </div>
-          <div className="shrink-0 flex flex-row justify-end items-center gap-2">
             {props.onCancel && (
-              <Button variant="plain" disabled={state.isRequesting} onClick={handleCancelBtnClick}>
-                {t("common.cancel")}
+              <Button variant="plain" size="sm" disabled={state.isRequesting} onClick={handleCancelBtnClick}>
+                <XIcon className="w-4 h-4 mx-auto text-gray-500 dark:text-gray-400" />
               </Button>
             )}
-            <Button color="primary" disabled={!allowSave || state.isRequesting} onClick={handleSaveBtnClick}>
-              {t("editor.save")}
-              {!state.isRequesting ? <SendIcon className="w-4 h-auto ml-1" /> : <LoaderIcon className="w-4 h-auto ml-1 animate-spin" />}
+            <Button variant="plain" size="sm" disabled={!allowSave || state.isRequesting} onClick={handleSaveBtnClick} className="group">
+              {!state.isRequesting ? (
+                <SendIcon className="w-4 h-4 mx-auto text-primary" />
+              ) : (
+                <LoaderIcon className="w-4 h-4 mx-auto animate-spin text-primary" />
+              )}
             </Button>
           </div>
         </div>

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -162,7 +162,7 @@ const MemoView: React.FC<Props> = (props: Props) => {
   return (
     <div
       className={clsx(
-        "group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
+        "group relative flex flex-col justify-start items-start w-full p-3 pb-2 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
         props.showPinned && memo.pinned && "border-gray-200 border dark:border-zinc-700",
         className,
       )}
@@ -171,7 +171,7 @@ const MemoView: React.FC<Props> = (props: Props) => {
       {showEditor ? (
         <MemoEditor
           autoFocus
-          className="border-none !p-0 -mb-2"
+          className="border-none !p-0"
           cacheKey={`inline-memo-editor-${memo.name}`}
           memoName={memo.name}
           onConfirm={() => setShowEditor(false)}


### PR DESCRIPTION
## Summary
- Reduce icon sizes from 20px to 16px throughout the editor for a more compact design
- Redesign action button layout by moving visibility selector and save button to the right side
- Replace text-based save button with icon-only design using SendIcon
- Adjust padding and spacing across all editor components for better visual consistency
- Temporarily hide markdown menu component
- Update MemoView padding to match editor style

## Changes
### Component Updates
- **AddMemoRelationPopover**: Reduced icon size, adjusted popover width, refined spacing and font sizes
- **LocationSelector**: Smaller icons for location pin and remove button
- **MarkdownMenu**: Compact menu items with reduced icon sizes and spacing
- **TagSelector**: Smaller icons and reduced text size for tag list
- **UploadResourceButton**: Reduced icon size to match other action buttons
- **Editor**: Changed textarea font size to `text-sm` and default rows to 2
- **MemoEditor**: Major layout redesign - moved controls to single row with right-aligned save/cancel buttons
- **MemoView**: Updated padding to match editor component

## Visual Impact
The changes create a more compact and modern interface while maintaining usability. The new layout is cleaner with all controls consolidated into a single row at the bottom of the editor.

## Test plan
- [x] Verify all action buttons display correctly with new icon sizes
- [x] Test tag selector interaction and display
- [x] Check memo relation popover functionality
- [x] Verify visibility selector works with icon-only display
- [x] Test save and cancel button functionality
- [x] Confirm resource upload button works
- [x] Validate location selector display when location is selected
- [x] Check overall visual consistency across light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)