### PR TITLE
feat: add resizable splitter for Timeline/Pinned layout

### DIFF
--- a/web/src/components/ResizableSplitter.tsx
+++ b/web/src/components/ResizableSplitter.tsx
@@ -1,26 +1,28 @@
 import { useCallback, useEffect, useState } from "react";
 
-interface ResizableSplitterProps {
-  leftPanelId?: string;
-  rightPanelId?: string;
-  minLeftWidth?: number;
-  minRightWidth?: number;
-  defaultLeftWidth?: number;
+interface Props {
+  timelinePanelId?: string;
+  pinnedPanelId?: string;
+  minTimelineWidth?: number;
+  minPinnedWidth?: number;
+  defaultTimelineWidth?: number;
   localStorageKey?: string;
 }
 
-const ResizableSplitter: React.FC<ResizableSplitterProps> = ({
-  leftPanelId = "left-panel",
-  rightPanelId = "right-panel",
-  minLeftWidth = 300,
-  minRightWidth = 300,
-  defaultLeftWidth = 50,
-  localStorageKey = "memos-splitter-width",
-}) => {
+const ResizableSplitter = (props: Props) => {
+  const {
+    timelinePanelId = "timeline-panel",
+    pinnedPanelId = "pinned-panel",
+    minTimelineWidth = 300,
+    minPinnedWidth = 300,
+    defaultTimelineWidth = 50,
+    localStorageKey = "memos-splitter-width",
+  } = props;
+
   const [isDragging, setIsDragging] = useState(false);
-  const [leftWidth, setLeftWidth] = useState<number>(() => {
+  const [timelineWidth, setTimelineWidth] = useState<number>(() => {
     const saved = localStorage.getItem(localStorageKey);
-    return saved ? parseFloat(saved) : defaultLeftWidth;
+    return saved ? parseFloat(saved) : defaultTimelineWidth;
   });
 
   const handleMouseDown = useCallback(() => {
@@ -31,23 +33,23 @@ const ResizableSplitter: React.FC<ResizableSplitterProps> = ({
     (e: MouseEvent) => {
       if (!isDragging) return;
 
-      const container = document.getElementById(leftPanelId)?.parentElement;
+      const container = document.getElementById(timelinePanelId)?.parentElement;
       if (!container) return;
 
       const containerRect = container.getBoundingClientRect();
       const containerWidth = containerRect.width;
       const offsetX = e.clientX - containerRect.left;
 
-      const newLeftWidthPx = offsetX;
-      const newRightWidthPx = containerWidth - offsetX;
+      const newTimelineWidthPx = offsetX;
+      const newPinnedWidthPx = containerWidth - offsetX;
 
-      if (newLeftWidthPx >= minLeftWidth && newRightWidthPx >= minRightWidth) {
-        const newLeftWidthPercent = (newLeftWidthPx / containerWidth) * 100;
-        setLeftWidth(newLeftWidthPercent);
-        localStorage.setItem(localStorageKey, newLeftWidthPercent.toString());
+      if (newTimelineWidthPx >= minTimelineWidth && newPinnedWidthPx >= minPinnedWidth) {
+        const newTimelineWidthPercent = (newTimelineWidthPx / containerWidth) * 100;
+        setTimelineWidth(newTimelineWidthPercent);
+        localStorage.setItem(localStorageKey, newTimelineWidthPercent.toString());
       }
     },
-    [isDragging, leftPanelId, minLeftWidth, minRightWidth, localStorageKey],
+    [isDragging, timelinePanelId, minTimelineWidth, minPinnedWidth, localStorageKey],
   );
 
   const handleMouseUp = useCallback(() => {
@@ -71,21 +73,21 @@ const ResizableSplitter: React.FC<ResizableSplitterProps> = ({
   }, [isDragging, handleMouseMove, handleMouseUp]);
 
   useEffect(() => {
-    const leftPanel = document.getElementById(leftPanelId);
-    const rightPanel = document.getElementById(rightPanelId);
+    const timelinePanel = document.getElementById(timelinePanelId);
+    const pinnedPanel = document.getElementById(pinnedPanelId);
 
-    if (leftPanel) {
-      leftPanel.style.width = `${leftWidth}%`;
+    if (timelinePanel) {
+      timelinePanel.style.width = `${timelineWidth}%`;
     }
-    if (rightPanel) {
-      rightPanel.style.width = `${100 - leftWidth}%`;
+    if (pinnedPanel) {
+      pinnedPanel.style.width = `${100 - timelineWidth}%`;
     }
-  }, [leftWidth, leftPanelId, rightPanelId]);
+  }, [timelineWidth, timelinePanelId, pinnedPanelId]);
 
   return (
     <div
-      className={`hidden lg:flex relative w-1 cursor-col-resize group hover:bg-blue-500 transition-colors ${
-        isDragging ? "bg-blue-500" : "bg-transparent"
+      className={`hidden lg:flex relative w-1 mx-2 cursor-col-resize group hover:bg-teal-600 dark:hover:bg-teal-500 transition-colors ${
+        isDragging ? "bg-teal-600 dark:bg-teal-500" : "bg-transparent"
       }`}
       onMouseDown={handleMouseDown}
     >
@@ -93,7 +95,7 @@ const ResizableSplitter: React.FC<ResizableSplitterProps> = ({
       <div
         className={`absolute inset-y-0 left-1/2 -translate-x-1/2 w-1 transition-opacity ${
           isDragging ? "opacity-100" : "opacity-0 group-hover:opacity-100"
-        } bg-blue-500`}
+        } bg-teal-600 dark:bg-teal-500`}
       />
     </div>
   );

--- a/web/src/components/ScrollToTop.tsx
+++ b/web/src/components/ScrollToTop.tsx
@@ -37,7 +37,7 @@ const ScrollToTop = ({ className, style, enabled = true, scrollContainerRef }: S
       scrollContainer.addEventListener("scroll", handleScroll);
       return () => scrollContainer.removeEventListener("scroll", handleScroll);
     }
-  }, [enabled, isVisible]);
+  }, [enabled, isVisible, scrollContainerRef]);
 
   const scrollToTop = () => {
     if (!scrollContainerRef.current) {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -19,7 +19,7 @@ const Home = () => {
   const { md } = useResponsiveWidth();
   const user = useCurrentUser();
   const memoFilterStore = useMemoFilterStore();
-  const scrollContainerRef = useRef<HTMLElement>(null);
+  const mobileScrollContainerRef = useRef<HTMLElement>(null);
 
   const memoRenderer = useCallback(
     (memo: Memo) => <MemoView key={`${memo.name}-${memo.displayTime}`} memo={memo} showVisibility showPinned showExport compact />,
@@ -84,7 +84,7 @@ const Home = () => {
   }, [user, memoFilterStore.filters, memoFilterStore.orderByTimeAsc]);
 
   return (
-    <section ref={scrollContainerRef} className="@container w-full h-screen overflow-y-auto md:overflow-visible md:flex md:flex-col">
+    <section ref={mobileScrollContainerRef} className="@container w-full h-screen overflow-y-auto md:overflow-visible md:flex md:flex-col">
       {!md && (
         <div className="sticky top-0 z-10 bg-zinc-100 dark:bg-zinc-900">
           <MobileHeader>
@@ -99,17 +99,17 @@ const Home = () => {
           <HomeSidebar className="py-6" />
         </div>
         <div className="flex-1 flex px-4 md:px-6 pb-4 md:pb-0 md:pt-3 md:h-full lg:pt-6 overflow-x-hidden">
-          <div id="left-panel" className="lg:w-1/2 flex-grow flex flex-col min-w-0 md:h-full md:overflow-y-auto">
+          <div id="timeline-panel" className="lg:w-1/2 flex-grow flex flex-col min-w-0 md:h-full md:overflow-y-auto">
             {md && <div className="shrink-0">{editorSection}</div>}
             <PagedMemoList
               renderer={memoRenderer}
               listSort={listSort}
               filter={memoListFilter}
-              scrollContainerRef={!md ? scrollContainerRef : undefined}
+              scrollContainerRef={!md ? mobileScrollContainerRef : undefined}
             />
           </div>
           <ResizableSplitter />
-          <div id="right-panel" className="hidden lg:flex lg:w-1/2 flex-col h-full overflow-y-auto lg:pl-4">
+          <div id="pinned-panel" className="hidden lg:flex lg:w-1/2 flex-col h-full overflow-y-auto">
             <PinnedMemoList renderer={memoRenderer} />
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Add draggable splitter between Timeline and Pinned sections to allow users to customize column widths
- Persist width setting in LocalStorage
- Use teal color scheme to match project theme
- Implement hover-visible drag handle with visual feedback

## Changes

- Created `ResizableSplitter` component with drag-to-resize functionality
- Integrated splitter into Home page layout
- Use `ResizeObserver` for scroll-to-top button positioning when panel width changes
- Semantic naming (timeline/pinned instead of left/right)

## Test plan

- [x] Drag the splitter to resize columns
- [x] Refresh page and verify width persists
- [x] Switch between mobile and desktop layouts
- [x] Verify scroll-to-top button position updates correctly

Fixes #46

🤖 Generated with [Claude Code](https://claude.ai/claude-code)