### PR TITLE
fix: update content-syntax documentation link in editor

### DIFF
--- a/web/src/components/MemoEditor/ActionButton/MarkdownMenu.tsx
+++ b/web/src/components/MemoEditor/ActionButton/MarkdownMenu.tsx
@@ -77,7 +77,7 @@ const MarkdownMenu = (props: Props) => {
           <span>{t("markdown.checkbox")}</span>
         </MenuItem>
         <div className="py-0.5 pl-2">
-          <Link fontSize={11} href="https://www.usememos.com/docs/getting-started/content-syntax" target="_blank">
+          <Link fontSize={11} href="https://www.usememos.com/docs/usage/writing-markdown" target="_blank">
             {t("markdown.content-syntax")}
           </Link>
         </div>


### PR DESCRIPTION
Updated the markdown menu link from the old URL to the new URL.

Fixes #56

Generated with [Claude Code](https://claude.ai/code)