### PR TITLE
feat: Hide Resources tab when no resources exist

### DIFF
--- a/web/src/components/Navigation.tsx
+++ b/web/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ import { NavLink } from "react-router-dom";
 import Tooltip from "@/components/ui/Tooltip";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { Routes } from "@/router";
-import { useInboxStore } from "@/store/v1";
+import { useInboxStore, useResourceStore } from "@/store/v1";
 import { useTranslate } from "@/utils/i18n";
 import UserBanner from "./UserBanner";
 
@@ -36,12 +36,16 @@ const Navigation = (props: Props) => {
   const t = useTranslate();
   const user = useCurrentUser();
   const inboxStore = useInboxStore();
+  const resourceStore = useResourceStore();
+  const hasResources = resourceStore.resourceList.length > 0;
+
   useEffect(() => {
     if (!user) {
       return;
     }
 
     inboxStore.fetchInboxes();
+    resourceStore.fetchResources();
     // Fetch inboxes every 5 minutes.
     const timer = setInterval(
       async () => {
@@ -111,7 +115,15 @@ const Navigation = (props: Props) => {
   };
 
   const navLinks: NavLinkItem[] = user
-    ? [homeNavLink, resourcesNavLink, exploreNavLink, reviewNavLink, profileNavLink, archivedNavLink, settingNavLink]
+    ? [
+        homeNavLink,
+        ...(hasResources ? [resourcesNavLink] : []),
+        exploreNavLink,
+        reviewNavLink,
+        profileNavLink,
+        archivedNavLink,
+        settingNavLink,
+      ]
     : [exploreNavLink, signInNavLink, aboutNavLink];
 
   return (

--- a/web/src/pages/Resources.tsx
+++ b/web/src/pages/Resources.tsx
@@ -9,10 +9,9 @@ import ResourceIcon from "@/components/ResourceIcon";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import Tooltip from "@/components/ui/Tooltip";
-import { resourceServiceClient } from "@/grpcweb";
 import useLoading from "@/hooks/useLoading";
 import i18n from "@/i18n";
-import { useMemoStore } from "@/store/v1";
+import { useMemoStore, useResourceStore } from "@/store/v1";
 import { Resource } from "@/types/proto/api/v1/resource_service";
 import { useTranslate } from "@/utils/i18n";
 
@@ -41,14 +40,14 @@ const Resources = () => {
     searchQuery: "",
   });
   const memoStore = useMemoStore();
-  const [resources, setResources] = useState<Resource[]>([]);
+  const resourceStore = useResourceStore();
+  const resources = resourceStore.resourceList;
   const filteredResources = resources.filter((resource) => includes(resource.filename, state.searchQuery));
   const groupedResources = groupResourcesByDate(filteredResources.filter((resource) => resource.memo));
   const unusedResources = filteredResources.filter((resource) => !resource.memo);
 
   useEffect(() => {
-    resourceServiceClient.listResources({}).then(({ resources }) => {
-      setResources(resources);
+    resourceStore.fetchResources().then((resources) => {
       loadingState.setFinish();
       Promise.all(resources.map((resource) => (resource.memo ? memoStore.getOrFetchMemoByName(resource.memo) : null)));
     });
@@ -58,9 +57,8 @@ const Resources = () => {
     const confirmed = window.confirm("Are you sure to delete all unused resources? This action cannot be undone.");
     if (confirmed) {
       for (const resource of unusedResources) {
-        await resourceServiceClient.deleteResource({ name: resource.name });
+        await resourceStore.deleteResource(resource.name);
       }
-      setResources(resources.filter((resource) => resource.memo));
     }
   };
 

--- a/web/src/store/v1/resource.ts
+++ b/web/src/store/v1/resource.ts
@@ -5,16 +5,27 @@ import { CreateResourceRequest, Resource, UpdateResourceRequest } from "@/types/
 
 interface State {
   resourceMapByName: Record<string, Resource>;
+  resourceList: Resource[];
 }
 
 const getDefaultState = (): State => ({
   resourceMapByName: {},
+  resourceList: [],
 });
 
 export const useResourceStore = create(
   combine(getDefaultState(), (set, get) => ({
     setState: (state: State) => set(state),
     getState: () => get(),
+    fetchResources: async () => {
+      const { resources } = await resourceServiceClient.listResources({});
+      const resourceMap = get().resourceMapByName;
+      resources.forEach((resource) => {
+        resourceMap[resource.name] = resource;
+      });
+      set({ resourceMapByName: resourceMap, resourceList: resources });
+      return resources;
+    },
     fetchResourceByUID: async (uid: string) => {
       const resource = await resourceServiceClient.getResourceByUid({
         uid,
@@ -32,13 +43,24 @@ export const useResourceStore = create(
       const resource = await resourceServiceClient.createResource(create);
       const resourceMap = get().resourceMapByName;
       resourceMap[resource.name] = resource;
+      const resourceList = [...get().resourceList, resource];
+      set({ resourceMapByName: resourceMap, resourceList });
       return resource;
     },
     async updateResource(update: UpdateResourceRequest): Promise<Resource> {
       const resource = await resourceServiceClient.updateResource(update);
       const resourceMap = get().resourceMapByName;
       resourceMap[resource.name] = resource;
+      const resourceList = get().resourceList.map((r) => (r.name === resource.name ? resource : r));
+      set({ resourceMapByName: resourceMap, resourceList });
       return resource;
+    },
+    async deleteResource(name: string): Promise<void> {
+      await resourceServiceClient.deleteResource({ name });
+      const resourceMap = get().resourceMapByName;
+      delete resourceMap[name];
+      const resourceList = get().resourceList.filter((r) => r.name !== name);
+      set({ resourceMapByName: resourceMap, resourceList });
     },
   })),
 );


### PR DESCRIPTION
Closes #82

## Changes

- Extended resource store with `resourceList`, `fetchResources`, and `deleteResource`
- Navigation fetches resources on mount and hides the Resources tab when the list is empty
- Resources page now uses the store so deletions update the tab reactively

Generated with [Claude Code](https://claude.ai/code)